### PR TITLE
Fix shared_ptr to bool conversion error

### DIFF
--- a/library/cpp/derived_stats.h
+++ b/library/cpp/derived_stats.h
@@ -317,7 +317,7 @@ class DerivedStatsPeriodicIf {
             // There were no updates to the DerivedStats
             // since the last flush
             dsm_cache_.reset();
-            return dsm_cache_;
+            return dsm_cache_.get();
         }
         dsm_cache_ = boost::make_shared<std::map<std::string,ResultT> >();
         for (typename result_map::const_iterator dit = dsm_->begin();
@@ -332,7 +332,7 @@ class DerivedStatsPeriodicIf {
 
         // Clear the DerivedStats
         dsm_.reset();
-        return dsm_cache_;
+        return dsm_cache_.get();
     }
 
     // This is the interface to retrieve the current value


### PR DESCRIPTION
http://ci.wincontrail.codilime.com:8080/job/Wincontrail/job/build-vrouter-agent/58/console
```cl.exe /Fobuild\debug\analytics\collector_uve_types.o /c build\debug\analytics\collector_uve_types.cpp /TP /Iwindows /GS /analyze- /w /Zc:wchar_t /Od /Zc:inline /fp:precise /D_WIN32_WINNT=0x0601 /D "_WINDOWS" /D "WIN32" /D "CURL_STATICLIB" /D "_DEBUG" /D "_CONSOLE" /errorReport:prompt /WX- /w /wd4996 /wd4150 /Zc:forScope /RTC1 /Gd /Oy- /MDd /Fa"Debug" /EHsc "/D "_DEBUG"" /w /D NOMINMAX /Icontroller\src /Ibuild\include /Icontroller\lib /IJ:\usr\include\python2.7 /IJ:\usr\include\librdkafka /Ibuild\debug\tools\sandesh\library\common /Itools\sandesh\library\common /Ibuild\debug\io /Icontroller\src\io /Ibuild\debug\database /Icontroller\src\database /Ibuild\debug\database\cassandra\cql /Icontroller\src\database\cassandra\cql /Ibuild\debug /Ibuild\debug\http\client /Icontroller\src\http\client /Ibuild\debug\discovery\client /Icontroller\src\discovery\client /Ibuild\debug\analytics /Icontroller\src\analytics /Ibuild\debug /Ibuild\debug\base\sandesh /Icontroller\src\base\sandesh /Z7
Microsoft (R) C/C++ Optimizing Compiler Version 19.00.24215.1 for x86
Copyright (C) Microsoft Corporation.  All rights reserved.

collector_uve_types.cpp
J:\workspace\build-vrouter---4cd830f6\build\include\sandesh/derived_stats.h(320): error C2440: 'return': cannot convert from 'boost::shared_ptr<std::map<std::string,GenDb::DbTableStat_P_,std::less<_Kty>,std::allocator<std::pair<const _Kty,_Ty>>>>' to 'bool'
        with
        [
            _Kty=std::string,
            _Ty=GenDb::DbTableStat_P_
        ]
J:\workspace\build-vrouter---4cd830f6\build\include\sandesh/derived_stats.h(320): note: No user-defined-conversion operator available that can perform this conversion, or the operator cannot be called
J:\workspace\build-vrouter---4cd830f6\build\include\sandesh/derived_stats.h(314): note: while compiling class template member function 'bool contrail::sandesh::DerivedStatsPeriodicIf<contrail::sandesh::DSSum,GenDb::DbTableStat,GenDb::DbTableStat,GenDb::DbTableStat_P_>::Flush(const std::map<std::string,GenDb::DbTableStat_P_,std::less<_Kty>,std::allocator<std::pair<const _Kty,_Ty>>> &)'
        with
        [
            _Kty=std::string,
            _Ty=GenDb::DbTableStat_P_
        ]
build\debug\analytics\collector_uve_types.cpp(5373): note: see reference to function template instantiation 'bool contrail::sandesh::DerivedStatsPeriodicIf<contrail::sandesh::DSSum,GenDb::DbTableStat,GenDb::DbTableStat,GenDb::DbTableStat_P_>::Flush(const std::map<std::string,GenDb::DbTableStat_P_,std::less<_Kty>,std::allocator<std::pair<const _Kty,_Ty>>> &)' being compiled
        with
        [
            _Kty=std::string,
            _Ty=GenDb::DbTableStat_P_
        ]
build\debug\analytics\collector_uve_types.cpp(5371): note: see reference to class template instantiation 'contrail::sandesh::DerivedStatsPeriodicIf<contrail::sandesh::DSSum,GenDb::DbTableStat,GenDb::DbTableStat,GenDb::DbTableStat_P_>' being compiled
J:\workspace\build-vrouter---4cd830f6\build\include\boost/bind/placeholders.hpp(54): note: see reference to class template instantiation 'boost::arg<9>' being compiled
J:\workspace\build-vrouter---4cd830f6\build\include\boost/bind/placeholders.hpp(53): note: see reference to class template instantiation 'boost::arg<8>' being compiled
J:\workspace\build-vrouter---4cd830f6\build\include\boost/bind/placeholders.hpp(52): note: see reference to class template instantiation 'boost::arg<7>' being compiled
J:\workspace\build-vrouter---4cd830f6\build\include\boost/bind/placeholders.hpp(51): note: see reference to class template instantiation 'boost::arg<6>' being compiled
J:\workspace\build-vrouter---4cd830f6\build\include\boost/bind/placeholders.hpp(50): note: see reference to class template instantiation 'boost::arg<5>' being compiled
J:\workspace\build-vrouter---4cd830f6\build\include\boost/bind/placeholders.hpp(49): note: see reference to class template instantiation 'boost::arg<4>' being compiled
J:\workspace\build-vrouter---4cd830f6\build\include\boost/bind/placeholders.hpp(48): note: see reference to class template instantiation 'boost::arg<3>' being compiled
J:\workspace\build-vrouter---4cd830f6\build\include\boost/bind/placeholders.hpp(47): note: see reference to class template instantiation 'boost::arg<2>' being compiled
J:\workspace\build-vrouter---4cd830f6\build\include\boost/bind/placeholders.hpp(46): note: see reference to class template instantiation 'boost::arg<1>' being compiled
J:\workspace\build-vrouter---4cd830f6\build\include\sandesh/derived_stats.h(335): error C2440: 'return': cannot convert from 'boost::shared_ptr<std::map<std::string,GenDb::DbTableStat_P_,std::less<_Kty>,std::allocator<std::pair<const _Kty,_Ty>>>>' to 'bool'
        with
        [
            _Kty=std::string,
            _Ty=GenDb::DbTableStat_P_
        ]
J:\workspace\build-vrouter---4cd830f6\build\include\sandesh/derived_stats.h(335): note: No user-defined-conversion operator available that can perform this conversion, or the operator cannot be called
scons: *** [build\debug\analytics\collector_uve_types.o] Error 2
scons: building terminated because of errors.```